### PR TITLE
PLAT-1327: suppression du loader Tiff de Mitk (itk)

### DIFF
--- a/Modules/Core/src/mitkCoreActivator.cpp
+++ b/Modules/Core/src/mitkCoreActivator.cpp
@@ -38,6 +38,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include <itkNiftiImageIO.h>
 #include <itkGDCMImageIO.h>
+#include "itkTIFFImageIO.h"
 
 // Micro Services
 #include <usGetModuleContext.h>
@@ -408,6 +409,12 @@ void MitkCoreActivator::RegisterItkReaderWriter()
       // MITK provides its own DICOM reader (which internally uses GDCMImageIO).
       continue;
     }
+
+	// skip TIFF because Platypus has its own
+	if (dynamic_cast<itk::TIFFImageIO*>(io))
+	{
+		continue;
+	}
 
     if (io)
     {


### PR DESCRIPTION
suppression du loader Tiff de Mitk dans le module Activator de MitkCore

Pas trouvé d'autre solution que de supprimer l'enregistrement du Tiff IO provenant de Itk dans l'activateur de MitKCore.

Ajouter la copie de d->m_Reg nécessite d'autres corrections pour le Unregister ne plante pas et de toute façon ça provoque des plantages un peu partout. En imaginant qu'on les résolve, il n'y a en fait faire de compteur sur le nombre de Clones créés, et chaque destructeur tenterait de désenregistrer le service (qui ne fonctionnerait donc qu'une seule fois). Le fait qu'on ne puisse pas désenreistrer le service à partir d'un Clone semble donc fait exprès, mais il semble ne pas y avoir de méthode qui permettent de récupérer l'original permettant de désenregistrer le service.*

Une autre solution consisterait à dés-enregistrer le MimeType lui-même, mais là encore il semble de rient y avoir pour le faire.
