### PR TITLE
Added berry::Job::AddJobChangeListener proxy implementation

### DIFF
--- a/Plugins/org.blueberry.core.jobs/src/berryJob.cpp
+++ b/Plugins/org.blueberry.core.jobs/src/berryJob.cpp
@@ -125,6 +125,11 @@ void Job::RemoveJobChangeListener(IJobChangeListener* listener)
   InternalJob::RemoveJobChangeListener(listener);
 }
 
+void Job::AddJobChangeListener(IJobChangeListener* listener)
+{
+  InternalJob::AddJobChangeListener(listener);
+}
+
 void Job::Schedule()
 {
   Poco::Timestamp::TimeDiff tmpNoDelay = 0;


### PR DESCRIPTION
The proxy method berry::Job::AddJobChangeListener, calling berry::InternalJob::berry::Job::AddJobChangeListener was missing, making the whole API quite unusable.
