### PR TITLE
PLAT-1279 removing registration to addNodeEvent to prevent any suppresion of any interactors added before the event is fired

### DIFF
--- a/Modules/Core/src/Interactions/mitkBindDispatcherInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkBindDispatcherInteractor.cpp
@@ -71,8 +71,8 @@ void mitk::BindDispatcherInteractor::RegisterDataStorageEvents()
 {
   if (m_DataStorage.IsNotNull())
   {
-    m_DataStorage->AddNodeEvent.AddListener(
-        MessageDelegate1<BindDispatcherInteractor, const DataNode*>(this, &BindDispatcherInteractor::RegisterInteractor));
+  //  m_DataStorage->AddNodeEvent.AddListener(
+   //     MessageDelegate1<BindDispatcherInteractor, const DataNode*>(this, &BindDispatcherInteractor::RegisterInteractor));
 
     m_DataStorage->RemoveNodeEvent.AddListener(
         MessageDelegate1<BindDispatcherInteractor, const DataNode*>(this, &BindDispatcherInteractor::UnRegisterInteractor));
@@ -104,8 +104,8 @@ void mitk::BindDispatcherInteractor::UnRegisterDataStorageEvents()
 {
   if (m_DataStorage.IsNotNull())
   {
-    m_DataStorage->AddNodeEvent.RemoveListener(
-        MessageDelegate1<BindDispatcherInteractor, const DataNode*>(this, &BindDispatcherInteractor::RegisterInteractor));
+   // m_DataStorage->AddNodeEvent.RemoveListener(
+   //     MessageDelegate1<BindDispatcherInteractor, const DataNode*>(this, &BindDispatcherInteractor::RegisterInteractor));
     m_DataStorage->RemoveNodeEvent.RemoveListener(
         MessageDelegate1<BindDispatcherInteractor, const DataNode*>(this, &BindDispatcherInteractor::UnRegisterInteractor));
     m_DataStorage->InteractorChangedNodeEvent.RemoveListener(


### PR DESCRIPTION
When a new  dataNode is added, the bindDispatcher calls the methode AddDataInteractor which checks that any created interactors does not have the new node linked to it. If so, the link between the node and the interactor is destroyed.
When a new interactor is added to the node, the same method is called (checking that the node is not linked to any interactors, then adding the interactor).

If the two events are received in the reverse order, the dataNode is linked to the interactor, then the linked is broken.
This can happen with two rendering windows and two dispatchers

We suppose that when a node is added to the datastorage it has not been linked with any data interactor (default behaviour of the measurement toolbox view), so we disconnect the registration to this event (which is supposed to be useless) to prevent any wrong behaviour.
