### PR TITLE
PLAT-1516 forbid empty editor stash container to duplicate into empty children

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/internal/berryPartSashContainer.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryPartSashContainer.cpp
@@ -153,9 +153,11 @@ void PartSashContainer::DropObject(const QList<PartPane::Pointer>& toDrop,
       LayoutPart::Pointer next = toDrop[idx];
       this->Stack(next, newPart);
     }
-
-    this->AddEnhanced(newPart, side, this->GetDockingRatio(newPart, targetStack),
+    if (toDrop.size() > 0)
+    {
+      this->AddEnhanced(newPart, side, this->GetDockingRatio(newPart, targetStack),
         targetLayoutPart);
+    }
   }
 
   if (visiblePart != 0)


### PR DESCRIPTION
When closing an editor, the workbench keeps its partSashContainer (the grey box where the editor was). This is supposed to be the behaviour of eclipse.

When someone tries to move this part inside itself, it duplicates it, thus doubling the number of empty part sash in the workbench (this can be done again and again).

This pull request prevent the workbench to create a new part sash container if the current droped container contains nothing
