### PR TITLE
Plat 1490 magnetic figures

### DIFF
--- a/Modules/Core/include/mitkInteractionEventHandler.h
+++ b/Modules/Core/include/mitkInteractionEventHandler.h
@@ -41,11 +41,11 @@ namespace mitk
    *  It provides an interface to load configuration objects map of events to variant names.
    */
   class InteractionEvent;
-  class MITKCORE_EXPORT InteractionEventHandler : public itk::LightObject
+  class MITKCORE_EXPORT InteractionEventHandler : public itk::Object
   {
 
   public:
-    mitkClassMacroItkParent(InteractionEventHandler, itk::LightObject)
+    mitkClassMacroItkParent(InteractionEventHandler, itk::Object)
 
     /**
      * @brief Loads a configuration from an XML resource.

--- a/Modules/Core/src/Interactions/mitkDispatcher.cpp
+++ b/Modules/Core/src/Interactions/mitkDispatcher.cpp
@@ -139,7 +139,15 @@ bool mitk::Dispatcher::ProcessEvent(InteractionEvent* event)
     // give event to selected interactor
     if (eventIsHandled == false && m_SelectedInteractor.IsNotNull())
     {
-      eventIsHandled = m_SelectedInteractor->HandleEvent(event, m_SelectedInteractor->GetDataNode());
+     // eventIsHandled = m_SelectedInteractor->HandleEvent(event, m_SelectedInteractor->GetDataNode());
+      const std::list<DataInteractor::Pointer> tmpInteractorList(m_Interactors);
+      std::list<DataInteractor::Pointer>::const_iterator it;
+      for (it = tmpInteractorList.cbegin(); it != tmpInteractorList.cend(); ++it)
+      {
+        DataInteractor::Pointer dataInteractor = *it;
+        eventIsHandled |= (*it)->HandleEvent(event, dataInteractor->GetDataNode());
+      }
+      // delete re
     }
     break;
 
@@ -182,7 +190,7 @@ bool mitk::Dispatcher::ProcessEvent(InteractionEvent* event)
           m_ProcessingMode = CONNECTEDMOUSEACTION;
         }
         eventIsHandled = true;
-        break;
+       // break;
       }
     }
   }


### PR DESCRIPTION
Turned the interactor into itk object so that they can interact between each other via itk events
The dispatcher behavior was to process mouse events until one figure catches it and then stop the event chain.
So that when a point was beeing clicked and draged, only the figure which was beeing modified was aware of the user interaction, thus other figures could not react.
The choice of implementation for the magnetic feature is that when the mouse hover the images, each figure checks if it is close to itself, and if so, send an event to the currently modified figure.
So every figure has to be aware of the user interaction
