### PR TITLE
Deactivate default JPEG reader

### DIFF
--- a/Modules/Core/src/mitkCoreActivator.cpp
+++ b/Modules/Core/src/mitkCoreActivator.cpp
@@ -39,6 +39,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <itkNiftiImageIO.h>
 #include <itkGDCMImageIO.h>
 #include "itkTIFFImageIO.h"
+#include "itkJPEGImageIO.h"
 
 // Micro Services
 #include <usGetModuleContext.h>
@@ -415,6 +416,13 @@ void MitkCoreActivator::RegisterItkReaderWriter()
 	{
 		continue;
 	}
+
+    // skip JPEG because Platypus has its own
+	if (dynamic_cast<itk::JPEGImageIO*>(io))
+	{
+		continue;
+	}
+
 
     if (io)
     {


### PR DESCRIPTION
Comment out the default ITK jpeg reader to let our reader to be automatically picked up
