### PR TITLE
Add IsEditorAreaVisible and SetEditorAreaVisible in IWorkbenchPage

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/berryIWorkbenchPage.h
+++ b/Plugins/org.blueberry.ui.qt/src/berryIWorkbenchPage.h
@@ -864,6 +864,25 @@ struct BERRY_UI_QT IWorkbenchPage : public IPartService, public ISelectionServic
    *         reference can be found.
    */
   virtual IWorkbenchPartReference::Pointer GetReference(IWorkbenchPart::Pointer part) = 0;
+
+  /**
+  * Returns whether the page's current perspective is showing the editor
+  * area.
+  *
+  * @return <code>true</code> when editor area visible, <code>false</code>
+  *         otherwise
+  */
+  virtual bool IsEditorAreaVisible() = 0;
+
+  /**
+  * Show or hide the editor area for the page's active perspective.
+  *
+  * @param showEditorArea
+  *            <code>true</code> to show the editor area,
+  *            <code>false</code> to hide the editor area
+  */
+  virtual void SetEditorAreaVisible(bool showEditorArea) = 0;
+
 };
 
 }  // namespace berry

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchPage.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchPage.h
@@ -969,7 +969,7 @@ public:
   /**
    * See IWorkbenchPage.
    */
-  bool IsEditorAreaVisible();
+  bool IsEditorAreaVisible() override;
 
   /**
    * Returns whether the view is fast.
@@ -1184,7 +1184,7 @@ public:
   /**
    * See IWorkbenchPage.
    */
-  void SetEditorAreaVisible(bool showEditorArea);
+  void SetEditorAreaVisible(bool showEditorArea) override;
 
   /**
    * Sets the perspective.


### PR DESCRIPTION
Functions already exist in WorkbenchPage but not in the Interface IWorkbenchPage (contrary to java implementation).

I strongly supposed It will be very usefull when we will want to avoid the editor area to be displayed automatically when we open an image (or other things) in perspective when we do not want to see the editor area. Or if we want to hide the editor area when we close the editor...
