### PR TITLE
PLAT-1373 Removed ad-hoc tolerance which has no reason to be here and moreover was unit dependant

### DIFF
--- a/Modules/PlanarFigure/src/DataManagement/mitkPlanarPolygon.cpp
+++ b/Modules/PlanarFigure/src/DataManagement/mitkPlanarPolygon.cpp
@@ -194,7 +194,7 @@ bool mitk::PlanarPolygon::CheckForLineIntersection( const mitk::Point2D& p1, con
   const double x = ( pre * (x3 - x4) - (x1 - x2) * post ) / d;
   const double y = ( pre * (y3 - y4) - (y1 - y2) * post ) / d;
 
-  double tolerance = 0.001;
+  double tolerance = 0.00;
   // Check if the x coordinates are within both lines, including tolerance
   if ( x < ( std::min(x1, x2) - tolerance )
     || x > ( std::max(x1, x2) + tolerance )


### PR DESCRIPTION
There is a tolerance in mitk to check if a given point is located on the interesection of 2 lines défined by points P1,P2 and P3,P4.

A tolerance was given to check this. This is wrong, we do not need any tolerance, PLUS this tolerance is unit dependant, it is rather low in mitk because units are in milimeter but it is huge in platypus as units are in nanometer (so both lines always appear to collide)
