### PR TITLE
Plat 1779 multi view

### DIFF
--- a/Modules/Core/src/Interactions/mitkBindDispatcherInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkBindDispatcherInteractor.cpp
@@ -62,7 +62,7 @@ void mitk::BindDispatcherInteractor::RegisterInteractor(const mitk::DataNode* da
 {
   if (m_Dispatcher.IsNotNull())
   {
-    m_Dispatcher->AddDataInteractor(dataNode);
+    //m_Dispatcher->AddDataInteractor(dataNode);
   }
 
 }

--- a/Modules/QtWidgets/include/QmitkNodeDescriptorManager.h
+++ b/Modules/QtWidgets/include/QmitkNodeDescriptorManager.h
@@ -68,6 +68,13 @@ public:
   QmitkNodeDescriptor* GetDescriptor(const mitk::DataNode* _Node) const;
 
   ///
+  /// Get all the descriptor in the descriptors list that matches the given node.
+  /// \return a List of QmitkNodeDescriptor for the given node or a QmitkNodeDescriptor describing unknown nodes (never 0)
+  /// \sa AddDescriptor()
+  ///
+  QList<QmitkNodeDescriptor*> GetDescriptorList(const mitk::DataNode * _Node) const;
+
+  ///
   /// Get the last QmitkNodeDescriptor for the given class name
   ///
   /// \return a QmitkNodeDescriptor for the given class name or 0 if there is no QmitkNodeDescriptor for _ClassName

--- a/Modules/QtWidgets/src/QmitkNodeDescriptorManager.cpp
+++ b/Modules/QtWidgets/src/QmitkNodeDescriptorManager.cpp
@@ -103,6 +103,23 @@ QmitkNodeDescriptor* QmitkNodeDescriptorManager::GetDescriptor( const mitk::Data
   return _Descriptor;
 }
 
+QList<QmitkNodeDescriptor*> QmitkNodeDescriptorManager::GetDescriptorList(const mitk::DataNode* _Node) const
+{
+  QList<QmitkNodeDescriptor*> _Descriptor;
+
+  for (QList<QmitkNodeDescriptor*>::const_iterator it = m_NodeDescriptors.begin(); it != m_NodeDescriptors.end(); ++it)
+  {
+    if ((*it)->CheckNode(_Node))
+      _Descriptor.append(*it);
+  }
+  if (_Descriptor.size() == 0)
+  {
+    _Descriptor.append(m_UnknownDataNodeDescriptor);
+  }
+  return _Descriptor;
+}
+
+
 QmitkNodeDescriptor* QmitkNodeDescriptorManager::GetDescriptor( const QString& _ClassName ) const
 {
   QmitkNodeDescriptor* _Descriptor = 0;
@@ -145,14 +162,13 @@ QList<QAction*> QmitkNodeDescriptorManager::GetActions( const mitk::DataNode* _N
 QList<QAction*> QmitkNodeDescriptorManager::GetActions( const QList<mitk::DataNode::Pointer> &_Nodes ) const
 {
   QList<QAction*> actions = m_UnknownDataNodeDescriptor->GetBatchActions();
-  QSet<QmitkNodeDescriptor*> nodeDescriptors;
   QmitkNodeDescriptor* lastDescriptor;
+  QList<QmitkNodeDescriptor*> nodeDescriptors;
 
   // find all descriptors for the nodes (unique)
   foreach (mitk::DataNode::Pointer node, _Nodes)
   {
-    lastDescriptor = this->GetDescriptor(node);
-    nodeDescriptors.insert(lastDescriptor);
+    nodeDescriptors.append(this->GetDescriptorList(node));
   }
   // add all actions for the found descriptors
   lastDescriptor = m_UnknownDataNodeDescriptor;

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryPerspective.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryPerspective.h
@@ -41,7 +41,7 @@ class PerspectiveHelper;
  * \ingroup org_blueberry_ui_internal
  *
  */
-class Perspective : public Object {
+class BERRY_UI_QT Perspective : public Object {
 
 public:
 

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryViewFactory.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryViewFactory.h
@@ -37,7 +37,7 @@ struct IViewRegistry;
  * It implements a reference counting strategy so that one view can be shared
  * by more than one client.
  */
-class ViewFactory { // implements IExtensionChangeHandler {
+class BERRY_UI_QT ViewFactory { // implements IExtensionChangeHandler {
 
 private:
 


### PR DESCRIPTION
- The user is fully responsible for adding and removing interactors from renderers (and not the dispatcher)
- Added a method to get all the descriptors (Qmitk) for a given node (when the user right click on several nodes in datamanager, this allow to execute all possible actions on selected nodes)
- Allow access to 3 class in blueberry to unlock window placement in code