### PR TITLE
PLAT-1949 force labelsetimage mapper to reinitialize when node is modified

### DIFF
--- a/Modules/Multilabel/mitkLabelSetImageVtkMapper2D.cpp
+++ b/Modules/Multilabel/mitkLabelSetImageVtkMapper2D.cpp
@@ -528,7 +528,8 @@ void mitk::LabelSetImageVtkMapper2D::Update(mitk::BaseRenderer* renderer)
   //check if something important has changed and we need to re-render
 
   //(localStorage->m_LastDataUpdateTime < node->GetMTime()) // this one is too generic
-  if ( (localStorage->m_LastDataUpdateTime < image->GetMTime()) //was the data modified?
+  if ((localStorage->m_LastDataUpdateTime < node->GetMTime())
+       || (localStorage->m_LastDataUpdateTime < image->GetMTime()) //was the data modified?
        || (localStorage->m_LastDataUpdateTime < image->GetPipelineMTime())
        || (localStorage->m_LastDataUpdateTime < renderer->GetCurrentWorldPlaneGeometryUpdateTime()) //was the geometry modified?
        || (localStorage->m_LastDataUpdateTime < renderer->GetCurrentWorldPlaneGeometry()->GetMTime())


### PR DESCRIPTION
Reactivated a feature commented in mitk : 
For performance purpose, labelsetimage mapper reinitialization was deactivated unless there was modification on node geometry or data itself.
During this initialization the node'depth (the z position on the viewport) is chosen according to node layer (the position in the datamanager). So this depth was fixed at initialization.
In platypus, we are playing and switching layers as we are adding/removing nodes and changing orders in the datamanager. 
Modifing the layer property did not trigger the mapper reinitialization (as it is linked to the node and neither the data nor the geometry), so the depth was fixed and from time to time, the parent image of the segmentation was drawn over the segmentation itself.
