### PR TITLE
Fixes on the use of ctk Locations

### DIFF
--- a/CMakeExternals/CTK.patch
+++ b/CMakeExternals/CTK.patch
@@ -84,3 +84,15 @@ diff -rub CTK/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp CTK.updated/Li
    return d->fwFactory->getFramework()->getPluginContext();
  }
  
+diff -rub CTK/Libs/PluginFramework/ctkLDAPExpr.cpp CTK.updated/Libs/PluginFramework/ctkLDAPExpr.cpp
+--- CTK/Libs/PluginFramework/ctkLDAPExpr.cpp  2016-02-29 04:51:39.000000000 +0100
++++ CTK.updated/Libs/PluginFramework/ctkLDAPExpr.cpp  2017-06-15 11:10:25.186841400 +0200
+@@ -189,7 +189,7 @@
+ {
+   if (d->m_operator == EQ)
+   {
+-    if (d->m_attrName.compare(ctkPluginConstants::OBJECTCLASS, Qt::CaseInsensitive) &&
++    if (d->m_attrName.compare(ctkPluginConstants::OBJECTCLASS, Qt::CaseInsensitive) == 0 &&
+       d->m_attrValue.indexOf(WILDCARD) < 0) 
+     {
+       objClasses.insert( d->m_attrValue );

--- a/Plugins/org.blueberry.core.runtime/src/internal/berryInternalPlatform.cpp
+++ b/Plugins/org.blueberry.core.runtime/src/internal/berryInternalPlatform.cpp
@@ -315,6 +315,26 @@ void InternalPlatform::CloseServiceTrackers()
     m_DebugTracker->close();
     m_DebugTracker.reset();
   }
+
+  if (!configurationLocation.isNull()) {
+    configurationLocation->close();
+    configurationLocation.reset();
+  }
+
+  if (!installLocation.isNull()) {
+    installLocation->close();
+    installLocation.reset();
+  }
+
+  if (!instanceLocation.isNull()) {
+    instanceLocation->close();
+    instanceLocation.reset();
+  }
+
+  if (!userLocation.isNull()) {
+    userLocation->close();
+    userLocation.reset();
+  }
 }
 
 void InternalPlatform::InitializeDebugFlags()
@@ -345,13 +365,13 @@ ctkLocation* InternalPlatform::GetConfigurationLocation()
 ctkLocation* InternalPlatform::GetInstallLocation()
 {
   this->AssertInitialized();
-  return configurationLocation->getService();
+  return installLocation->getService();
 }
 
 ctkLocation* InternalPlatform::GetInstanceLocation()
 {
   this->AssertInitialized();
-  return installLocation->getService();
+  return instanceLocation->getService();
 }
 
 QDir InternalPlatform::GetStateLocation(const QSharedPointer<ctkPlugin>& plugin)


### PR DESCRIPTION
1/ the patch is a correction in ctk itself, ctkLDAPExpr::getMatchedObjectClasses: a problem in the condition of an if statement prevent from getting location services

2/ two bugs in blueberry InternalPlatform class: 2a/confusion between service variables installLocation and instanceLocation, and 2b/ locations were not closed correctly that gives a segfault when the application stops

We did not see the bug 2b/ until now because the bug 1/  makes all location pointer null and not opened