### PR TITLE
Enforce OpenCV to compile its internal jpeg, tiff and png codecs

### DIFF
--- a/CMakeExternals/OpenCV.cmake
+++ b/CMakeExternals/OpenCV.cmake
@@ -79,6 +79,9 @@ if(MITK_USE_OpenCV)
       CMAKE_GENERATOR ${gen}
       CMAKE_ARGS
         ${ep_common_args}
+        -DBUILD_JPEG=ON
+        -DBUILD_TIFF=ON
+        -DBUILD_PNG=ON
         -DBUILD_TESTS:BOOL=OFF
         -DBUILD_DOCS:BOOL=OFF
         -DBUILD_EXAMPLES:BOOL=OFF


### PR DESCRIPTION
This fix some issues since TensorFlow has been integrated: for some reason JPG processing with OpenCV was triggering a segfault.