### PR TITLE
Fix figure interaction to handle strange events

### DIFF
--- a/Modules/Core/src/Interactions/mitkDispatcher.cpp
+++ b/Modules/Core/src/Interactions/mitkDispatcher.cpp
@@ -125,11 +125,16 @@ bool mitk::Dispatcher::ProcessEvent(InteractionEvent* event)
       return true;
     }
   }
+
+  if (!m_SelectedInteractor)
+  {
+    m_ProcessingMode = REGULAR;
+  }
   switch (m_ProcessingMode)
   {
   case CONNECTEDMOUSEACTION:
     // finished connected mouse action
-    if (std::strcmp(p->GetNameOfClass(), "MouseReleaseEvent") == 0)
+    if (std::strcmp(p->GetNameOfClass(), "MouseReleaseEvent") == 0 && m_SelectedInteractor.IsNotNull())
     {
       m_ProcessingMode = REGULAR;
       eventIsHandled = m_SelectedInteractor->HandleEvent(event, m_SelectedInteractor->GetDataNode());


### PR DESCRIPTION
Sometime when strange events happened (triple click, figure move while a double click is still under processing). Event processing mode and selected interactor were melt. Now if the selected interactor is null, the event is considered as normal (normal means no click and drag or double click)